### PR TITLE
Fix npm check to use function if provided

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -19,11 +19,8 @@ function error {
 # Utilities to check core dependencies
 #
 function check_npm_installed {
-    if [ -z "$(which npm)" ] ;
-    then
-        error "Node and npm are required"
-        exit 1;
-    fi
+    # Taken from http://stackoverflow.com/a/677212
+    command -v npm >/dev/null 2>&1 || { error "Node and npm are required" ; exit 1; }
 }
 
 function check_deps {


### PR DESCRIPTION
update the way npm is checked to allow functio usage.

When no npm is found, the main script aliases npm to a function leveraging docker containers.