### PR TITLE
Fix obselete ember-simple-auth version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-intl": "2.0.0-beta.18",
-    "ember-simple-auth": "simplabs/ember-simple-auth#jj-abrams",
+    "ember-simple-auth": "^1.0.1",
     "express": "^4.8.5",
     "glob": "^4.0.5",
     "http-proxy": "^1.8.1",


### PR DESCRIPTION
The simplabs/ember-simple-auth "jj-abrams" branch no longer exists.

**Why 1.0.1 ?**
"jj-abrams" date from 13/10 and has never been merged. So there is not
a specific commit that can ensure compatibility : let's choose an
*arbitrary* stable version.
- v0.8 is too old (June)
- v1.0 date from 16/10.
- v1.0.1 date from 20/10. Latest version.